### PR TITLE
check for JObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ src/Skybrud.Essentials/Skybrud.Essentials.csproj.DotSettings
 releases/nuget/Skybrud.Essentials.*/
 releases/github/Skybrud.Essentials.*/
 src/.vs/
+src/.idea/

--- a/src/Skybrud.Essentials/Json/Extensions/JObjectExtensions.cs
+++ b/src/Skybrud.Essentials/Json/Extensions/JObjectExtensions.cs
@@ -466,8 +466,9 @@ namespace Skybrud.Essentials.Json.Extensions {
             if (!(obj?.SelectToken(path) is JArray token)) return null;
 
             return (
-                from JObject child in token
-                select callback(child)
+                from child in token
+                where child is JObject
+                select callback((JObject)child)
             ).ToArray();
 
         }


### PR DESCRIPTION
I notice some weird behavior of Umbraco and sometimes you finish with JSON like that:
`{
	"name": "Full Width",
	"sections": [
		{
			"grid": 12,
			"rows": [
				
				{
					"name": "12",
					"areas": [
						{
							"grid": 12,
							"allowAll": false,
							"allowed": [
								"rte"
							],
							"hasConfig": false,
							"controls": [
								{
									"value": "Value",
									"editor": {
										"alias": "headline"
									},
									"active": false
								}
							
							]
						}
					],
					"label": "Full Width",
					"hasConfig": false,
				},
				{
					"name": "12",
					"areas": [
						{
							"grid": 12,
							"allowAll": false,
							"allowed": [
								"rte"
							],
							"hasConfig": false,
							"controls": [
								{
									"value": "Value 2",
									"editor": {
										"alias": "headline"
									},
									"active": false
								}
								
					],
					"label": "Full Width",
					"hasConfig": false,
				},
				null,
				{
					"name": "12",
					"areas": [
						{
							"grid": 12,
							"allowAll": false,
							"allowed": [
								"rte"
							],
							"hasConfig": false,
							"controls": [
									{
									"value": "Value 3",
									"editor": {
										"alias": "headline"
									},
									"active": false
								}
							],
							"active": true,
							"hasActiveChild": true
						}
					],
					"label": "Full Width",
					"hasConfig": false,
					"hasActiveChild": true,
					"active": true
				}
			]
		}
	]
}`
And because of that I make little change to be sure that "NULL ROW" will not affect casting to strong  typed grid.