### PR TITLE
Implemented `Extends` and `Implements` extension methods for the `Type` class

### DIFF
--- a/src/Skybrud.Essentials/Reflection/Extensions/ReflectionExtensions.cs
+++ b/src/Skybrud.Essentials/Reflection/Extensions/ReflectionExtensions.cs
@@ -166,6 +166,26 @@ public static class ReflectionExtensions {
     }
 
     /// <summary>
+    /// Returns whether the type extends <typeparamref name="TClass"/>.
+    /// </summary>
+    /// <typeparam name="TClass">The type of the class to check.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="type"/> extends <typeparamref name="TClass"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Extends<TClass>(this Type type) {
+        return typeof(TClass).IsAssignableFrom(type);
+    }
+
+    /// <summary>
+    /// Returns whether the type implements <typeparamref name="TInterface"/>.
+    /// </summary>
+    /// <typeparam name="TInterface">The type of the interface to check.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="type"/> implements <typeparamref name="TInterface"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Implements<TInterface>(this Type type) {
+        return typeof(TInterface).IsAssignableFrom(type);
+    }
+
+    /// <summary>
     /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
     /// </summary>
     /// <param name="member">The member.</param>

--- a/src/Skybrud.Essentials/Reflection/Extensions/ReflectionExtensions.cs
+++ b/src/Skybrud.Essentials/Reflection/Extensions/ReflectionExtensions.cs
@@ -2,248 +2,246 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
-namespace Skybrud.Essentials.Reflection.Extensions {
+namespace Skybrud.Essentials.Reflection.Extensions;
+
+/// <summary>
+/// Extension methods for working with reflection.
+/// </summary>
+public static class ReflectionExtensions {
 
     /// <summary>
-    /// Extension methods for working with reflection.
+    /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
     /// </summary>
-    public static class ReflectionExtensions {
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this Enum value) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute<T>(value);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this Enum value) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute<T>(value);
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this Enum value, [NotNullWhen(true)] out T? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute(value, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this Enum value, [NotNullWhen(true)] out T? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute(value, out result);
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(this Enum value, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttributes(value, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(this Enum value, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttributes(value, out result);
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="value">The enum value to get the attribute for.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(this Enum value) where T : Attribute {
+        return ReflectionUtils.GetCustomAttribute<T>(value);
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="value">The enum value to get the attribute for.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(this Enum value) where T : Attribute {
-            return ReflectionUtils.GetCustomAttribute<T>(value);
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="value">The enum value to get attributes for.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(this Enum value) where T : Attribute {
+        return ReflectionUtils.GetCustomAttributes<T>(value);
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="value">The enum value to get attributes for.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(this Enum value) where T : Attribute {
-            return ReflectionUtils.GetCustomAttributes<T>(value);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="member">The member info.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this MemberInfo? member) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute<T>(member);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="member">The member info.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this MemberInfo? member) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute<T>(member);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="member">The member info.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this MemberInfo? member, [NotNullWhen(true)] out T? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute(member, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="member">The member info.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this MemberInfo? member, [NotNullWhen(true)] out T? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute(member, out result);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="member">The member info.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(this MemberInfo? member, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttributes(member, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="member">The member info.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(this MemberInfo? member, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttributes(member, out result);
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="member">The member holding the attribute.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(this MemberInfo? member) where T : Attribute {
+        return ReflectionUtils.GetCustomAttribute<T>(member);
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="member">The member holding the attribute.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(this MemberInfo? member) where T : Attribute {
-            return ReflectionUtils.GetCustomAttribute<T>(member);
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="member">The member holding the attributes.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(this MemberInfo? member) where T : Attribute {
+        return ReflectionUtils.GetCustomAttributes<T>(member);
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="member">The member holding the attributes.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(this MemberInfo? member) where T : Attribute {
-            return ReflectionUtils.GetCustomAttributes<T>(member);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="type">The type holding the attribute.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this Type? type) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute<T>(type);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="type">The type holding the attribute.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this Type? type) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute<T>(type);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="type">The type holding the attribute.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(this Type? type, [NotNullWhen(true)] out T? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttribute(type, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="type">The type holding the attribute.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(this Type? type, [NotNullWhen(true)] out T? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttribute(type, out result);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="type">The type holding the attributes.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(this Type type, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        return ReflectionUtils.HasCustomAttributes(type, out result);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="type">The type holding the attributes.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(this Type type, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            return ReflectionUtils.HasCustomAttributes(type, out result);
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="type">The type holding the attribute.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(this Type? type) where T : Attribute {
+        return ReflectionUtils.GetCustomAttribute<T>(type);
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="type">The type holding the attribute.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(this Type? type) where T : Attribute {
-            return ReflectionUtils.GetCustomAttribute<T>(type);
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="type">The type holding the attributes.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(this Type? type) where T : Attribute {
+        return ReflectionUtils.GetCustomAttributes<T>(type);
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="type">The type holding the attributes.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(this Type? type) where T : Attribute {
-            return ReflectionUtils.GetCustomAttributes<T>(type);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="member">The member.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this MemberInfo? member) {
+        return ReflectionUtils.IsObsolete(member, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="member">The member.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this MemberInfo? member) {
-            return ReflectionUtils.IsObsolete(member, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="member">The member.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this MemberInfo? member, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        return ReflectionUtils.IsObsolete(member, out attribute);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="member">The member.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this MemberInfo? member, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            return ReflectionUtils.IsObsolete(member, out attribute);
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="value">The enum value.</param>
+    /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this Enum value) {
+        return ReflectionUtils.IsObsolete(value, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="value">The enum value.</param>
-        /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this Enum value) {
-            return ReflectionUtils.IsObsolete(value, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="value" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="value">The enum value.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the enum value has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this Enum value, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        return ReflectionUtils.IsObsolete(value, out attribute);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="value" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="value">The enum value.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the enum value has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this Enum value, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            return ReflectionUtils.IsObsolete(value, out attribute);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this Type? type) {
+        return ReflectionUtils.IsObsolete(type, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this Type? type) {
-            return ReflectionUtils.IsObsolete(type, out _);
-        }
-
-        /// <summary>
-        /// Returns whether the specified <paramref name="type" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the type has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(this Type? type, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            return ReflectionUtils.IsObsolete(type, out attribute);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the type has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(this Type? type, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        return ReflectionUtils.IsObsolete(type, out attribute);
+    }
 
 #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> is an extension class.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns><c>true</c> if <paramref name="type"/> is an extension class; otherwise, <c>false</c>.</returns>
-        public static bool IsExtensionClass(this Type? type) {
-            return ReflectionUtils.IsExtensionClass(type);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> is an extension class.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is an extension class; otherwise, <c>false</c>.</returns>
+    public static bool IsExtensionClass(this Type? type) {
+        return ReflectionUtils.IsExtensionClass(type);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="method"/> is an extension method.
-        /// </summary>
-        /// <param name="method">The method.</param>
-        /// <returns><c>true</c> if <paramref name="method"/> is an extension method; otherwise, <c>false</c>.</returns>
-        public static bool IsExtensionMethod(this MethodInfo? method) {
-            return ReflectionUtils.IsExtensionMethod(method);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="method"/> is an extension method.
+    /// </summary>
+    /// <param name="method">The method.</param>
+    /// <returns><c>true</c> if <paramref name="method"/> is an extension method; otherwise, <c>false</c>.</returns>
+    public static bool IsExtensionMethod(this MethodInfo? method) {
+        return ReflectionUtils.IsExtensionMethod(method);
+    }
 
 #endif
-
-    }
 
 }

--- a/src/Skybrud.Essentials/Reflection/ReflectionUtils.cs
+++ b/src/Skybrud.Essentials/Reflection/ReflectionUtils.cs
@@ -132,6 +132,26 @@ public static class ReflectionUtils {
 #endif
 
     /// <summary>
+    /// Returns whether the type extends <typeparamref name="TClass"/>.
+    /// </summary>
+    /// <typeparam name="TClass">The type of the class to check.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="type"/> extends <typeparamref name="TClass"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Extends<TClass>(Type type) {
+        return typeof(TClass).IsAssignableFrom(type);
+    }
+
+    /// <summary>
+    /// Returns whether the type implements <typeparamref name="TInterface"/>.
+    /// </summary>
+    /// <typeparam name="TInterface">The type of the interface to check.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <returns><see langword="true"/> if <paramref name="type"/> implements <typeparamref name="TInterface"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool Implements<TInterface>(Type type) {
+        return typeof(TInterface).IsAssignableFrom(type);
+    }
+
+    /// <summary>
     /// Returns whether <typeparamref name="T"/> is a class type.
     /// </summary>
     /// <typeparam name="T">The type to check.</typeparam>

--- a/src/Skybrud.Essentials/Reflection/ReflectionUtils.cs
+++ b/src/Skybrud.Essentials/Reflection/ReflectionUtils.cs
@@ -7,579 +7,577 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Skybrud.Essentials.Collections;
 
-namespace Skybrud.Essentials.Reflection {
+namespace Skybrud.Essentials.Reflection;
+
+/// <summary>
+/// Static utility class for working with reflection.
+/// </summary>
+public static class ReflectionUtils {
 
     /// <summary>
-    /// Static utility class for working with reflection.
+    /// Returns the version of the specified <paramref name="assembly"/>.
     /// </summary>
-    public static class ReflectionUtils {
-
-        /// <summary>
-        /// Returns the version of the specified <paramref name="assembly"/>.
-        /// </summary>
-        /// <param name="assembly">The assembly.</param>
-        /// <returns>A string representing the version of the assembly.</returns>
-        public static string GetVersion(Assembly assembly) {
-            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            return assembly.GetName().Version?.ToString()!;
-        }
+    /// <param name="assembly">The assembly.</param>
+    /// <returns>A string representing the version of the assembly.</returns>
+    public static string GetVersion(Assembly assembly) {
+        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+        return assembly.GetName().Version?.ToString()!;
+    }
 
 #if I_CAN_HAZ_FILE_VERSION_INFO
 
-        /// <summary>
-        /// Returns the version of the assembly of the specified <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>A string representing the version of the assembly.</returns>
-        public static string GetVersion(Type type) {
-            return GetVersion(type.Assembly);
-        }
+    /// <summary>
+    /// Returns the version of the assembly of the specified <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>A string representing the version of the assembly.</returns>
+    public static string GetVersion(Type type) {
+        return GetVersion(type.Assembly);
+    }
 
-        /// <summary>
-        /// Returns the version of the assembly of the specified <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
-        /// <returns>A string representing the version of the assembly.</returns>
-        public static string GetVersion<T>() {
-            return GetVersion(typeof(T).Assembly);
-        }
+    /// <summary>
+    /// Returns the version of the assembly of the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
+    /// <returns>A string representing the version of the assembly.</returns>
+    public static string GetVersion<T>() {
+        return GetVersion(typeof(T).Assembly);
+    }
 
-        /// <summary>
-        /// Returns the file version of the specified <paramref name="assembly"/>.
-        /// </summary>
-        /// <param name="assembly">The assembly.</param>
-        /// <returns>A string representing the file version of the assembly.</returns>
-        public static string GetFileVersion(Assembly assembly) {
-            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            return FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion!;
-        }
+    /// <summary>
+    /// Returns the file version of the specified <paramref name="assembly"/>.
+    /// </summary>
+    /// <param name="assembly">The assembly.</param>
+    /// <returns>A string representing the file version of the assembly.</returns>
+    public static string GetFileVersion(Assembly assembly) {
+        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+        return FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion!;
+    }
 
-        /// <summary>
-        /// Returns the file version of the assembly of the specified <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>A string representing the file version of the assembly.</returns>
-        public static string GetFileVersion(Type type) {
-            return GetFileVersion(type.Assembly);
-        }
+    /// <summary>
+    /// Returns the file version of the assembly of the specified <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>A string representing the file version of the assembly.</returns>
+    public static string GetFileVersion(Type type) {
+        return GetFileVersion(type.Assembly);
+    }
 
-        /// <summary>
-        /// Returns the file version of the assembly of the specified <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
-        /// <returns>A string representing the file version of the assembly.</returns>
-        public static string GetFileVersion<T>() {
-            return GetFileVersion(typeof(T).Assembly);
-        }
+    /// <summary>
+    /// Returns the file version of the assembly of the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
+    /// <returns>A string representing the file version of the assembly.</returns>
+    public static string GetFileVersion<T>() {
+        return GetFileVersion(typeof(T).Assembly);
+    }
 
-        /// <summary>
-        /// Returns the informational version of the specified <paramref name="assembly"/>.
-        /// </summary>
-        /// <param name="assembly">The assembly.</param>
-        /// <returns>A string representing the informational version of the assembly.</returns>
-        public static string GetInformationalVersion(Assembly assembly) {
-            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion!;
-        }
+    /// <summary>
+    /// Returns the informational version of the specified <paramref name="assembly"/>.
+    /// </summary>
+    /// <param name="assembly">The assembly.</param>
+    /// <returns>A string representing the informational version of the assembly.</returns>
+    public static string GetInformationalVersion(Assembly assembly) {
+        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+        return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion!;
+    }
 
-        /// <summary>
-        /// Returns the informational version of the assembly of the specified <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>A string representing the informational version of the assembly.</returns>
-        public static string GetInformationalVersion(Type type) {
-            return GetInformationalVersion(type.Assembly);
-        }
+    /// <summary>
+    /// Returns the informational version of the assembly of the specified <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>A string representing the informational version of the assembly.</returns>
+    public static string GetInformationalVersion(Type type) {
+        return GetInformationalVersion(type.Assembly);
+    }
 
-        /// <summary>
-        /// Returns the informational version of the assembly of the specified <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
-        /// <returns>A string representing the informational version of the assembly.</returns>
-        public static string GetInformationalVersion<T>() {
-            return GetInformationalVersion(typeof(T).Assembly);
-        }
+    /// <summary>
+    /// Returns the informational version of the assembly of the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
+    /// <returns>A string representing the informational version of the assembly.</returns>
+    public static string GetInformationalVersion<T>() {
+        return GetInformationalVersion(typeof(T).Assembly);
+    }
 
-        /// <summary>
-        /// Returns an instance of <see cref="FileVersionInfo"/> with information about the specified <paramref name="assembly"/>.
-        /// </summary>
-        /// <param name="assembly">The assembly.</param>
-        /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
-        public static FileVersionInfo GetFileVersionInfo(Assembly assembly) {
-            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
-            return FileVersionInfo.GetVersionInfo(assembly.Location);
-        }
+    /// <summary>
+    /// Returns an instance of <see cref="FileVersionInfo"/> with information about the specified <paramref name="assembly"/>.
+    /// </summary>
+    /// <param name="assembly">The assembly.</param>
+    /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
+    public static FileVersionInfo GetFileVersionInfo(Assembly assembly) {
+        if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+        return FileVersionInfo.GetVersionInfo(assembly.Location);
+    }
 
-        /// <summary>
-        /// Returns an instance of <see cref="FileVersionInfo"/> with information about the assembly of the specified <paramref name="type"/>.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
-        public static FileVersionInfo GetFileVersionInfo(Type type) {
-            if (type == null) throw new ArgumentNullException(nameof(type));
-            return GetFileVersionInfo(type.Assembly);
-        }
+    /// <summary>
+    /// Returns an instance of <see cref="FileVersionInfo"/> with information about the assembly of the specified <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
+    public static FileVersionInfo GetFileVersionInfo(Type type) {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        return GetFileVersionInfo(type.Assembly);
+    }
 
-        /// <summary>
-        /// Returns an instance of <see cref="FileVersionInfo"/> with information about the assembly of the specified <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
-        /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
-        public static FileVersionInfo GetFileVersionInfo<T>() {
-            return GetFileVersionInfo(typeof(T).Assembly);
-        }
+    /// <summary>
+    /// Returns an instance of <see cref="FileVersionInfo"/> with information about the assembly of the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A type used for finding the underlying assembly.</typeparam>
+    /// <returns>An instance of <see cref="FileVersionInfo"/>.</returns>
+    public static FileVersionInfo GetFileVersionInfo<T>() {
+        return GetFileVersionInfo(typeof(T).Assembly);
+    }
 
 #endif
 
-        /// <summary>
-        /// Returns whether <typeparamref name="T"/> is a class type.
-        /// </summary>
-        /// <typeparam name="T">The type to check.</typeparam>
-        /// <returns><c>true</c> if <typeparamref name="T"/> is a class type; otherwise <c>false</c>.</returns>
-        public static bool IsClass<T>() {
-            return IsClass(typeof(T));
-        }
+    /// <summary>
+    /// Returns whether <typeparamref name="T"/> is a class type.
+    /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <returns><c>true</c> if <typeparamref name="T"/> is a class type; otherwise <c>false</c>.</returns>
+    public static bool IsClass<T>() {
+        return IsClass(typeof(T));
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> is a class type.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c> if <paramref name="type"/> is a class type; otherwise <c>false</c>.</returns>
-        public static bool IsClass(Type? type) {
-            return type is not null && type.GetTypeInfo().IsClass;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> is a class type.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is a class type; otherwise <c>false</c>.</returns>
+    public static bool IsClass(Type? type) {
+        return type is not null && type.GetTypeInfo().IsClass;
+    }
 
-        /// <summary>
-        /// Returns whether <typeparamref name="T"/> is an interface type.
-        /// </summary>
-        /// <typeparam name="T">The type to check.</typeparam>
-        /// <returns><c>true</c> if <typeparamref name="T"/> is an interface type; otherwise <c>false</c>.</returns>
-        public static bool IsInterface<T>() {
-            return IsInterface(typeof(T));
-        }
+    /// <summary>
+    /// Returns whether <typeparamref name="T"/> is an interface type.
+    /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <returns><c>true</c> if <typeparamref name="T"/> is an interface type; otherwise <c>false</c>.</returns>
+    public static bool IsInterface<T>() {
+        return IsInterface(typeof(T));
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> is an interface type.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c> if <paramref name="type"/> is an interface type; otherwise <c>false</c>.</returns>
-        public static bool IsInterface(Type? type) {
-            return type is not null && type.GetTypeInfo().IsInterface;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> is an interface type.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is an interface type; otherwise <c>false</c>.</returns>
+    public static bool IsInterface(Type? type) {
+        return type is not null && type.GetTypeInfo().IsInterface;
+    }
 
-        /// <summary>
-        /// Returns whether <typeparamref name="T"/> is an enum.
-        /// </summary>
-        /// <typeparam name="T">The type to check.</typeparam>
-        /// <returns><c>true</c> if <typeparamref name="T"/> is an enum; otherwise <c>false</c>.</returns>
-        public static bool IsEnum<T>() {
-            return IsEnum(typeof(T));
-        }
+    /// <summary>
+    /// Returns whether <typeparamref name="T"/> is an enum.
+    /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <returns><c>true</c> if <typeparamref name="T"/> is an enum; otherwise <c>false</c>.</returns>
+    public static bool IsEnum<T>() {
+        return IsEnum(typeof(T));
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> is an enum.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c> if <paramref name="type"/> is an enum; otherwise <c>false</c>.</returns>
-        public static bool IsEnum(Type? type) {
-            return type is not null && type.GetTypeInfo().IsEnum;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> is an enum.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is an enum; otherwise <c>false</c>.</returns>
+    public static bool IsEnum(Type? type) {
+        return type is not null && type.GetTypeInfo().IsEnum;
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="member">The method.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(MemberInfo? member) {
-            return IsObsolete(member, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="member">The method.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(MemberInfo? member) {
+        return IsObsolete(member, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="member">The method.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(MemberInfo? member, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            attribute = member?.GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
-            return attribute != null;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="member">The method.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(MemberInfo? member, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        attribute = member?.GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
+        return attribute != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="value">The enum value.</param>
-        /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(Enum value) {
-            return IsObsolete(value, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="value">The enum value.</param>
+    /// <returns><c>true</c> if the enum value has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(Enum value) {
+        return IsObsolete(value, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
-        /// </summary>
-        /// <param name="value">The enum value.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(Enum value, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            attribute = GetCustomAttribute<ObsoleteAttribute>(value);
-            return attribute != null;
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value" /> is marked as obsolete.
+    /// </summary>
+    /// <param name="value">The enum value.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the member has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(Enum value, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        attribute = GetCustomAttribute<ObsoleteAttribute>(value);
+        return attribute != null;
+    }
 
-        /// <summary>
-        /// Returns whether <paramref name="type"/> is marked as obsolete.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(Type? type) {
-            return IsObsolete(type, out _);
-        }
+    /// <summary>
+    /// Returns whether <paramref name="type"/> is marked as obsolete.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(Type? type) {
+        return IsObsolete(type, out _);
+    }
 
-        /// <summary>
-        /// Returns whether <paramref name="type"/> is marked as obsolete.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete(Type? type, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            attribute = type?.GetTypeInfo().GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
-            return attribute != null;
-        }
+    /// <summary>
+    /// Returns whether <paramref name="type"/> is marked as obsolete.
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete(Type? type, [NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        attribute = type?.GetTypeInfo().GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
+        return attribute != null;
+    }
 
-        /// <summary>
-        /// Returns whether <typeparamref name="T"/> is marked as obsolete.
-        /// </summary>
-        /// <typeparam name="T">The type to check.</typeparam>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete<T>() {
-            return IsObsolete<T>(out _);
-        }
+    /// <summary>
+    /// Returns whether <typeparamref name="T"/> is marked as obsolete.
+    /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete<T>() {
+        return IsObsolete<T>(out _);
+    }
 
-        /// <summary>
-        /// Returns whether <typeparamref name="T"/> is marked as obsolete.
-        /// </summary>
-        /// <typeparam name="T">The type to check.</typeparam>
-        /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
-        /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
-        public static bool IsObsolete<T>([NotNullWhen(true)] out ObsoleteAttribute? attribute) {
-            attribute = typeof(T).GetTypeInfo().GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
-            return attribute != null;
-        }
+    /// <summary>
+    /// Returns whether <typeparamref name="T"/> is marked as obsolete.
+    /// </summary>
+    /// <typeparam name="T">The type to check.</typeparam>
+    /// <param name="attribute">An instance of <see cref="T:System.ObsoleteAttribute" /> if the type has been marked as obsolete.</param>
+    /// <returns><c>true</c> if the member has been marked as obsolete; otherwise <c>false</c>.</returns>
+    public static bool IsObsolete<T>([NotNullWhen(true)] out ObsoleteAttribute? attribute) {
+        attribute = typeof(T).GetTypeInfo().GetCustomAttributes(true).OfType<ObsoleteAttribute>().FirstOrDefault();
+        return attribute != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(Enum value) where T : Attribute {
-            return HasCustomAttribute<T>(value, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(Enum value) where T : Attribute {
+        return HasCustomAttribute<T>(value, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(Enum value, [NotNullWhen(true)] out T? result) where T : Attribute {
-            result = GetCustomAttributes<T>(value).FirstOrDefault();
-            return result != null;
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(Enum value, [NotNullWhen(true)] out T? result) where T : Attribute {
+        result = GetCustomAttributes<T>(value).FirstOrDefault();
+        return result != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified enum <paramref name="value"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="value">The enum value.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(Enum value, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            result = GetCustomAttributes<T>(value);
-            return result.Length > 0;
-        }
+    /// <summary>
+    /// Returns whether the specified enum <paramref name="value"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="value">The enum value.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(Enum value, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        result = GetCustomAttributes<T>(value);
+        return result.Length > 0;
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="value">The enum value to get the attribute for.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(Enum value) where T : Attribute {
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="value">The enum value to get the attribute for.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(Enum value) where T : Attribute {
 
-            // Get the member of the enum value
-            MemberInfo? member = value.GetType().GetTypeInfo().GetDeclaredField(value.ToString());
+        // Get the member of the enum value
+        MemberInfo? member = value.GetType().GetTypeInfo().GetDeclaredField(value.ToString());
 
-            // Return an array of the found attributes
-            return member?
-                .GetCustomAttributes<T>(false)
-                .FirstOrDefault();
+        // Return an array of the found attributes
+        return member?
+            .GetCustomAttributes<T>(false)
+            .FirstOrDefault();
 
-        }
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="value">The enum value to get attributes for.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(Enum value) where T : Attribute {
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="value">The enum value to get attributes for.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(Enum value) where T : Attribute {
 
-            // Get the member of the enum value
-            MemberInfo? member = value.GetType().GetTypeInfo().GetDeclaredField(value.ToString());
-            if (member == null) return ArrayUtils.Empty<T>();
+        // Get the member of the enum value
+        MemberInfo? member = value.GetType().GetTypeInfo().GetDeclaredField(value.ToString());
+        if (member == null) return ArrayUtils.Empty<T>();
 
-            // Return an array of the found attributes
-            return member
-                .GetCustomAttributes<T>(false)
-                .ToArray();
+        // Return an array of the found attributes
+        return member
+            .GetCustomAttributes<T>(false)
+            .ToArray();
 
-        }
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="member">The member.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(MemberInfo? member) where T : Attribute {
-            return HasCustomAttribute<T>(member, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="member">The member.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(MemberInfo? member) where T : Attribute {
+        return HasCustomAttribute<T>(member, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="member">The member.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(MemberInfo? member, [NotNullWhen(true)] out T? result) where T : Attribute {
-            result = member?.GetCustomAttributes<T>().FirstOrDefault();
-            return result != null;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="member">The member.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(MemberInfo? member, [NotNullWhen(true)] out T? result) where T : Attribute {
+        result = member?.GetCustomAttributes<T>().FirstOrDefault();
+        return result != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="member"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="member">The member.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(MemberInfo? member, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            result = member?.GetCustomAttributes<T>().ToArray() ?? ArrayUtils.Empty<T>();
-            return result.Length > 0;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="member"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="member">The member.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(MemberInfo? member, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        result = member?.GetCustomAttributes<T>().ToArray() ?? ArrayUtils.Empty<T>();
+        return result.Length > 0;
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="member">The member holding the attribute.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(MemberInfo? member) where T : Attribute {
-            return member?
-                .GetCustomAttributes<T>(false)
-                .FirstOrDefault();
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="member">The member holding the attribute.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(MemberInfo? member) where T : Attribute {
+        return member?
+            .GetCustomAttributes<T>(false)
+            .FirstOrDefault();
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="member">The member holding the attributes.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(MemberInfo? member) where T : Attribute {
-            return member?
-                .GetCustomAttributes<T>(false)
-                .ToArray() ?? ArrayUtils.Empty<T>();
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="member">The member holding the attributes.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(MemberInfo? member) where T : Attribute {
+        return member?
+            .GetCustomAttributes<T>(false)
+            .ToArray() ?? ArrayUtils.Empty<T>();
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(Type? type) where T : Attribute {
-            return HasCustomAttribute<T>(type, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(Type? type) where T : Attribute {
+        return HasCustomAttribute<T>(type, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="type">The type to check.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
-        /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttribute<T>(Type? type, [NotNullWhen(true)] out T? result) where T : Attribute {
-            result = type?.GetTypeInfo().GetCustomAttributes<T>(false).FirstOrDefault();
-            return result != null;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <c>null</c> if no matches.</param>
+    /// <returns><c>true</c>c> if an attribute is found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttribute<T>(Type? type, [NotNullWhen(true)] out T? result) where T : Attribute {
+        result = type?.GetTypeInfo().GetCustomAttributes<T>(false).FirstOrDefault();
+        return result != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="type">The type to check.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
-        public static bool HasCustomAttributes<T>(Type? type, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            result = type?.GetTypeInfo().GetCustomAttributes<T>(false).ToArray() ?? ArrayUtils.Empty<T>();
-            return result.Length > 0;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="type">The type to check.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><c>true</c>c> if one or more attributes are found; otherwise <c>false</c>.</returns>
+    public static bool HasCustomAttributes<T>(Type? type, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        result = type?.GetTypeInfo().GetCustomAttributes<T>(false).ToArray() ?? ArrayUtils.Empty<T>();
+        return result.Length > 0;
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="type">The type holding the attribute.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(Type? type) where T : Attribute {
-            return type?
-                .GetTypeInfo()
-                .GetCustomAttributes<T>(false)
-                .FirstOrDefault();
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="type">The type holding the attribute.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(Type? type) where T : Attribute {
+        return type?
+            .GetTypeInfo()
+            .GetCustomAttributes<T>(false)
+            .FirstOrDefault();
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="type">The type holding the attributes.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(Type? type) where T : Attribute {
-            return type?
-                .GetTypeInfo()
-                .GetCustomAttributes<T>(false)
-                .ToArray() ?? ArrayUtils.Empty<T>();
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="type">The type holding the attributes.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(Type? type) where T : Attribute {
+        return type?
+            .GetTypeInfo()
+            .GetCustomAttributes<T>(false)
+            .ToArray() ?? ArrayUtils.Empty<T>();
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="assembly"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="assembly">The type to check.</param>
-        /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
-        public static bool HasCustomAttribute<T>(Assembly? assembly) where T : Attribute {
-            return HasCustomAttribute<T>(assembly, out _);
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="assembly"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="assembly">The type to check.</param>
+    /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
+    public static bool HasCustomAttribute<T>(Assembly? assembly) where T : Attribute {
+        return HasCustomAttribute<T>(assembly, out _);
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="assembly"/> has an attribute of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute.</typeparam>
-        /// <param name="assembly">The assembly to check.</param>
-        /// <param name="result">The first attribute of <typeparamref name="T"/>, or <see langword="null"/> if no matches.</param>
-        /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
-        public static bool HasCustomAttribute<T>(Assembly? assembly, [NotNullWhen(true)] out T? result) where T : Attribute {
-            result = assembly?.GetCustomAttributes<T>().FirstOrDefault();
-            return result != null;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="assembly"/> has an attribute of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute.</typeparam>
+    /// <param name="assembly">The assembly to check.</param>
+    /// <param name="result">The first attribute of <typeparamref name="T"/>, or <see langword="null"/> if no matches.</param>
+    /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
+    public static bool HasCustomAttribute<T>(Assembly? assembly, [NotNullWhen(true)] out T? result) where T : Attribute {
+        result = assembly?.GetCustomAttributes<T>().FirstOrDefault();
+        return result != null;
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="assembly"/> has one or more attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes.</typeparam>
-        /// <param name="assembly">The assembly to check.</param>
-        /// <param name="result">When this method returns, an array containing the matched attributes.</param>
-        /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
-        public static bool HasCustomAttributes<T>(Assembly? assembly, [NotNullWhen(true)] out T[]? result) where T : Attribute {
-            result = assembly?.GetCustomAttributes<T>().ToArray() ?? ArrayUtils.Empty<T>();
-            return result.Length > 0;
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="assembly"/> has one or more attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes.</typeparam>
+    /// <param name="assembly">The assembly to check.</param>
+    /// <param name="result">When this method returns, an array containing the matched attributes.</param>
+    /// <returns><see langword="true"/> if an attribute is found; otherwise, <see langword="false"/>.</returns>
+    public static bool HasCustomAttributes<T>(Assembly? assembly, [NotNullWhen(true)] out T[]? result) where T : Attribute {
+        result = assembly?.GetCustomAttributes<T>().ToArray() ?? ArrayUtils.Empty<T>();
+        return result.Length > 0;
+    }
 
-        /// <summary>
-        /// Returns the first attribute of type <typeparamref name="T"/>, or <see langword="null"/> if no matching attributes are found.
-        /// </summary>
-        /// <typeparam name="T">The type of the attribute to return.</typeparam>
-        /// <param name="assembly">The assembly holding the attribute.</param>
-        /// <returns>An instance of <typeparamref name="T"/>, or <see langword="null"/> if no matching attributes are found.</returns>
-        public static T? GetCustomAttribute<T>(Assembly? assembly) where T : Attribute {
-            return assembly?
-                .GetCustomAttributes<T>()
-                .FirstOrDefault();
-        }
+    /// <summary>
+    /// Returns the first attribute of type <typeparamref name="T"/>, or <see langword="null"/> if no matching attributes are found.
+    /// </summary>
+    /// <typeparam name="T">The type of the attribute to return.</typeparam>
+    /// <param name="assembly">The assembly holding the attribute.</param>
+    /// <returns>An instance of <typeparamref name="T"/>, or <see langword="null"/> if no matching attributes are found.</returns>
+    public static T? GetCustomAttribute<T>(Assembly? assembly) where T : Attribute {
+        return assembly?
+            .GetCustomAttributes<T>()
+            .FirstOrDefault();
+    }
 
-        /// <summary>
-        /// Returns an array of attributes of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the attributes to return.</typeparam>
-        /// <param name="assembly">The assembly holding the attributes.</param>
-        /// <returns>An array of <typeparamref name="T"/>.</returns>
-        public static T[] GetCustomAttributes<T>(Assembly? assembly) where T : Attribute {
-            return assembly?
-                .GetCustomAttributes<T>()
-                .ToArray() ?? ArrayUtils.Empty<T>();
-        }
+    /// <summary>
+    /// Returns an array of attributes of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the attributes to return.</typeparam>
+    /// <param name="assembly">The assembly holding the attributes.</param>
+    /// <returns>An array of <typeparamref name="T"/>.</returns>
+    public static T[] GetCustomAttributes<T>(Assembly? assembly) where T : Attribute {
+        return assembly?
+            .GetCustomAttributes<T>()
+            .ToArray() ?? ArrayUtils.Empty<T>();
+    }
 
 #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="type"/> is an extension class.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns><c>true</c> if <paramref name="type"/> is an extension class; otherwise, <c>false</c>.</returns>
-        public static bool IsExtensionClass(Type? type) {
-            return type is not null && type.IsDefined(typeof(ExtensionAttribute));
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="type"/> is an extension class.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns><c>true</c> if <paramref name="type"/> is an extension class; otherwise, <c>false</c>.</returns>
+    public static bool IsExtensionClass(Type? type) {
+        return type is not null && type.IsDefined(typeof(ExtensionAttribute));
+    }
 
-        /// <summary>
-        /// Returns whether the specified <typeparamref name="T"/> is an extension class.
-        /// </summary>
-        /// <typeparam name="T">The type.</typeparam>
-        /// <returns><c>true</c> if <typeparamref name="T"/> is an extension class; otherwise, <c>false</c>.</returns>
-        public static bool IsExtensionClass<T>() {
-            return typeof(T).IsDefined(typeof(ExtensionAttribute));
-        }
+    /// <summary>
+    /// Returns whether the specified <typeparamref name="T"/> is an extension class.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    /// <returns><c>true</c> if <typeparamref name="T"/> is an extension class; otherwise, <c>false</c>.</returns>
+    public static bool IsExtensionClass<T>() {
+        return typeof(T).IsDefined(typeof(ExtensionAttribute));
+    }
 
-        /// <summary>
-        /// Returns whether the specified <paramref name="method"/> is an extension method.
-        /// </summary>
-        /// <param name="method">The method.</param>
-        /// <returns><c>true</c> if <paramref name="method"/> is an extension method; otherwise, <c>false</c>.</returns>
-        public static bool IsExtensionMethod(MethodInfo? method) {
-            return method is not null && method.IsDefined(typeof(ExtensionAttribute));
-        }
+    /// <summary>
+    /// Returns whether the specified <paramref name="method"/> is an extension method.
+    /// </summary>
+    /// <param name="method">The method.</param>
+    /// <returns><c>true</c> if <paramref name="method"/> is an extension method; otherwise, <c>false</c>.</returns>
+    public static bool IsExtensionMethod(MethodInfo? method) {
+        return method is not null && method.IsDefined(typeof(ExtensionAttribute));
+    }
 
 #endif
 
-        /// <summary>
-        /// Returns the <see cref="MethodInfo"/> identified by the specified <paramref name="expression"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the expression.</typeparam>
-        /// <param name="expression">The expression.</param>
-        /// <returns>An instance of <see cref="MethodInfo"/>.</returns>
-        /// <exception cref="ArgumentException">If <paramref name="expression"/> is not a method expression.</exception>
-        public static MethodInfo GetMethodInfo<T>(Expression<T> expression) {
+    /// <summary>
+    /// Returns the <see cref="MethodInfo"/> identified by the specified <paramref name="expression"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the expression.</typeparam>
+    /// <param name="expression">The expression.</param>
+    /// <returns>An instance of <see cref="MethodInfo"/>.</returns>
+    /// <exception cref="ArgumentException">If <paramref name="expression"/> is not a method expression.</exception>
+    public static MethodInfo GetMethodInfo<T>(Expression<T> expression) {
 
-            if (expression.Body is not MethodCallExpression methodExpression) {
-                throw new ArgumentException($"Expression body is not of type MethodCallExpression: {expression}");
-            }
-
-            return methodExpression.Method;
-
+        if (expression.Body is not MethodCallExpression methodExpression) {
+            throw new ArgumentException($"Expression body is not of type MethodCallExpression: {expression}");
         }
 
-        /// <summary>
-        /// Returns the <see cref="PropertyInfo"/> identified by the specified <paramref name="expression"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of the expression.</typeparam>
-        /// <param name="expression">The expression.</param>
-        /// <returns>An instance of <see cref="PropertyInfo"/>.</returns>
-        /// <exception cref="ArgumentException">If <paramref name="expression"/> is not a property expression.</exception>
-        public static PropertyInfo GetPropertyInfo<T>(Expression<T> expression) {
+        return methodExpression.Method;
 
-            if (expression.Body is not MemberExpression member) {
-                throw new ArgumentException($"Expression body is not of type MemberExpression: {expression}");
-            }
+    }
 
-            if (member.Member is not PropertyInfo propertyInfo) {
-                throw new ArgumentException($"Expression member is not a property: {expression}");
-            }
+    /// <summary>
+    /// Returns the <see cref="PropertyInfo"/> identified by the specified <paramref name="expression"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the expression.</typeparam>
+    /// <param name="expression">The expression.</param>
+    /// <returns>An instance of <see cref="PropertyInfo"/>.</returns>
+    /// <exception cref="ArgumentException">If <paramref name="expression"/> is not a property expression.</exception>
+    public static PropertyInfo GetPropertyInfo<T>(Expression<T> expression) {
 
-            return propertyInfo;
-
+        if (expression.Body is not MemberExpression member) {
+            throw new ArgumentException($"Expression body is not of type MemberExpression: {expression}");
         }
+
+        if (member.Member is not PropertyInfo propertyInfo) {
+            throw new ArgumentException($"Expression member is not a property: {expression}");
+        }
+
+        return propertyInfo;
 
     }
 


### PR DESCRIPTION
The syntax or wording around the `IsAssignableFrom` method feels a bit weird, so this PR introduces `Extends` and `Implements` extension methods to be used as alternatives.

While the two methods do the same, the idea is that the `Extends` method can be used to check whether a `System.Type` extends a given class, and that the `Implements` method can be used to check whether a `System.Type` implements a given interface.